### PR TITLE
Fix on the CSRF tokens showing up in the filters.

### DIFF
--- a/data/generator/sfDoctrineModule/hadori/template/templates/_filters.php
+++ b/data/generator/sfDoctrineModule/hadori/template/templates/_filters.php
@@ -15,7 +15,7 @@
 
       <select class="filter-select">
         <option value=""><?php echo $this->renderHtmlText('-- Add Filter --') ?></option>
-        [?php foreach ($form as $name => $field): ?]
+        [?php foreach ($form as $name => $field):  if($name=='_csrf_token') continue; ?]
           <option value="[?php echo $name ?]">[?php echo $field->renderLabel() ?]</option>
         [?php endforeach ?]
       </select>


### PR DESCRIPTION
Quick fix to fix issue #15 .  If we see the CSRF Token simply continue the loop and do not output it.
